### PR TITLE
README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ func main() {
 }
 ```
 
-See the [examples](https://github.com/jpfuentes2/go-env/examples) folder.
+See the [examples](https://github.com/jpfuentes2/go-env/tree/master/examples) folder.
 
-### Multiple Rails Environments
+### Multiple Application Environments
 
 Export `GOENV` from your shell to specify a different env file to be loaded.
 


### PR DESCRIPTION
## Changes
- The examples link in the README is broken and 404s, insert the correct link
- Update the title the section about environments from “Multiple Rails Environments” to “Multiple Application Environments”, since this repository isn’t Rails-based
